### PR TITLE
FHG-4913 'How use' service redo journey

### DIFF
--- a/src/FamilyHubs.ServiceDirectory.Admin.Core/Models/JourneyCacheModel.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Core/Models/JourneyCacheModel.cs
@@ -44,5 +44,12 @@ public class JourneyCacheModel<TJourneyPage, TErrorId, TUserInput>
         UserInputJson = JsonSerializer.Serialize(userInput);
     }
 
+    public void ClearErrors()
+    {
+        ErrorState = null;
+        UserInputType = null;
+        UserInputJson = null;
+    }
+
     public bool Updated { get; set; }
 }

--- a/src/FamilyHubs.ServiceDirectory.Admin.Core/Models/JourneyFlow.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Core/Models/JourneyFlow.cs
@@ -1,6 +1,7 @@
 ﻿
 namespace FamilyHubs.ServiceDirectory.Admin.Core.Models;
 
+//todo: this is no longer generic
 public enum JourneyFlow
 {
     /// <summary>

--- a/src/FamilyHubs.ServiceDirectory.Admin.Core/Models/JourneyFlow.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Core/Models/JourneyFlow.cs
@@ -12,6 +12,7 @@ public enum JourneyFlow
     /// </summary>
     AddRedo,
     AddRedoLocation,
+    AddRedoHowUse,
     /// <summary>
     /// Editing a service, retrieving from and setting in the API.
     /// </summary>

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Journeys/JourneyFlowExtensions.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Journeys/JourneyFlowExtensions.cs
@@ -22,4 +22,14 @@ public static class JourneyFlowExtensions
 
         return flow;
     }
+
+    public static JourneyFlow? FromOptionalUrlString(string? urlString)
+    {
+        if (!Enum.TryParse(urlString, true, out JourneyFlow flow))
+        {
+            return null;
+        }
+
+        return flow;
+    }
 }

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Journeys/LocationJourneyPageExtensions.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Journeys/LocationJourneyPageExtensions.cs
@@ -17,7 +17,10 @@ public static class LocationJourneyPageExtensions
     }
 
     //todo: flow is only needed for initiator page. move initiator logic to where called for initiator page and remove flow param?
-    public static string GetPagePath(this LocationJourneyPage page, JourneyFlow flow, Journey journey)
+    public static string GetPagePath(
+        this LocationJourneyPage page,
+        JourneyFlow flow,
+        Journey journey)
     {
         if (page == LocationJourneyPage.Initiator)
         {
@@ -54,10 +57,13 @@ public static class LocationJourneyPageExtensions
         return LocationJourneyPage.Initiator + 1;
     }
 
-    public static string GetAddFlowStartPagePath(Journey journey)
+    public static string GetAddFlowStartPagePath(Journey journey, JourneyFlow? parentJourneyFlow)
     {
         //todo: add flow and journey in GetPathPath (obvs renamed)?
-        return $"{GetAddFlowStartPage().GetPagePath(JourneyFlow.Add, journey)}?flow={JourneyFlow.Add}&journey={journey}";
+
+        string parentJourneyFlowParam = parentJourneyFlow == null ? "" : $"&parentJourneyFlow={parentJourneyFlow}";
+
+        return $"{GetAddFlowStartPage().GetPagePath(JourneyFlow.Add, journey)}?flow={JourneyFlow.Add}&journey={journey}{parentJourneyFlowParam}";
     }
 
     public static string GetEditStartPagePath()

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Journeys/LocationJourneyPageExtensions.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Journeys/LocationJourneyPageExtensions.cs
@@ -17,35 +17,22 @@ public static class LocationJourneyPageExtensions
     }
 
     //todo: flow is only needed for initiator page. move initiator logic to where called for initiator page and remove flow param?
-    public static string GetPagePath(
-        this LocationJourneyPage page,
-        JourneyFlow flow,
-        Journey journey)
+    public static string GetPagePath(this LocationJourneyPage page, JourneyFlow flow)
     {
         if (page == LocationJourneyPage.Initiator)
         {
-            switch (journey)
+            switch (flow)
             {
-                case Journey.Location:
-                    switch (flow)
-                    {
-                        case JourneyFlow.Add:
-                        case JourneyFlow.AddRedo:
-                            //todo: consumers are going to add query params to welcome, which aren't needed
-                            return "/manage-locations";
-                        case JourneyFlow.Edit:
-                            // details is both the initiator and the final page of the journey
-                            page = LocationJourneyPage.Location_Details;
-                            break;
-                        default:
-                            throw new ArgumentOutOfRangeException(nameof(flow), flow, null);
-                    }
+                case JourneyFlow.Add:
+                case JourneyFlow.AddRedo:
+                    //todo: consumers are going to add query params to welcome, which aren't needed
+                    return "/manage-locations";
+                case JourneyFlow.Edit:
+                    // details is both the initiator and the final page of the journey
+                    page = LocationJourneyPage.Location_Details;
                     break;
-                case Journey.Service:
-                    //todo: do we need to carry around the service journey flow?
-                    return ServiceJourneyPage.Add_Location.GetPagePath(JourneyFlow.Add);
                 default:
-                    throw new SwitchExpressionException(journey);
+                    throw new ArgumentOutOfRangeException(nameof(flow), flow, null);
             }
         }
 
@@ -63,7 +50,7 @@ public static class LocationJourneyPageExtensions
 
         string parentJourneyFlowParam = parentJourneyFlow == null ? "" : $"&parentJourneyFlow={parentJourneyFlow}";
 
-        return $"{GetAddFlowStartPage().GetPagePath(JourneyFlow.Add, journey)}?flow={JourneyFlow.Add}&journey={journey}{parentJourneyFlowParam}";
+        return $"{GetAddFlowStartPage().GetPagePath(JourneyFlow.Add)}?flow={JourneyFlow.Add}&journey={journey}{parentJourneyFlowParam}";
     }
 
     public static string GetEditStartPagePath()

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/LocationPageModel.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/LocationPageModel.cs
@@ -2,6 +2,7 @@
 using FamilyHubs.ServiceDirectory.Admin.Core.DistributedCache;
 using FamilyHubs.ServiceDirectory.Admin.Core.Models;
 using FamilyHubs.ServiceDirectory.Admin.Core.Models.LocationJourney;
+using FamilyHubs.ServiceDirectory.Admin.Core.Models.ServiceJourney;
 using FamilyHubs.ServiceDirectory.Admin.Web.Errors;
 using FamilyHubs.ServiceDirectory.Admin.Web.Journeys;
 using FamilyHubs.SharedKernel.Identity;
@@ -142,7 +143,7 @@ public class LocationPageModel<TInput> : HeaderPageModel
 
         // if we're not redirecting to self
         //todo: look for redirectingToSelf=True also?
-        if (!(result is RedirectResult redirect && redirect.Url.StartsWith(CurrentPage.GetPagePath(Flow, Journey))))
+        if (!(result is RedirectResult redirect && redirect.Url.StartsWith(CurrentPage.GetPagePath(Flow))))
         {
             // clear the error state and user input
             LocationModel.ErrorState = null;
@@ -165,7 +166,7 @@ public class LocationPageModel<TInput> : HeaderPageModel
 
         string redirectingToSelfParam = redirectingToSelf ? "&redirectingToSelf=true" : "";
         string parentJourneyFlowParam = parentJourneyFlow == null ? "" : $"&parentJourneyFlow={parentJourneyFlow}";
-        return $"{page.GetPagePath(flow.Value, journey)}?journey={journey}&flow={flow.Value.ToUrlString()}{redirectingToSelfParam}{parentJourneyFlowParam}";
+        return $"{page.GetPagePath(flow.Value)}?journey={journey}&flow={flow.Value.ToUrlString()}{redirectingToSelfParam}{parentJourneyFlowParam}";
     }
 
     protected IActionResult RedirectToLocationPage(
@@ -226,6 +227,13 @@ public class LocationPageModel<TInput> : HeaderPageModel
         else
         {
             backUrlPage = LocationJourneyPage.Location_Details;
+        }
+
+        if (Journey == Journey.Service && backUrlPage == LocationJourneyPage.Initiator)
+        {
+            //todo: check for null?
+            //todo: there should be a method that adds the flow param. perhaps GetPagePath itself, as it looks like all callers do it
+            return $"{ServiceJourneyPage.Select_Location.GetPagePath(ParentJourneyFlow!.Value)}?flow={ParentJourneyFlow.Value}";
         }
 
         return GetLocationPageUrl(backUrlPage, Journey, Flow is JourneyFlow.AddRedo ? JourneyFlow.Add : Flow, ParentJourneyFlow);

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/LocationPageModel.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/LocationPageModel.cs
@@ -92,7 +92,8 @@ public class LocationPageModel<TInput> : HeaderPageModel
         else
         {
             // we don't save the model on Get, but we don't want the page to pick up the error state when the user has gone back
-            // (we'll clear the error state in the model on a non-redirect to self post
+            // (we'll clear the error state in the model on a non-redirect to self post)
+            //todo: call ClearErrors() instead?
             LocationModel.ErrorState = null;
             Errors = ErrorState.Empty;
 

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/ServicePageModel.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/ServicePageModel.cs
@@ -245,7 +245,7 @@ public class ServicePageModel<TInput> : HeaderPageModel
         return backUrlPage;
     }
 
-    protected string GenerateBackUrl()
+    protected virtual string GenerateBackUrl()
     {
         ServiceJourneyPage backUrlPage;
         switch (Flow)

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/ServicePageModel.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/ServicePageModel.cs
@@ -218,7 +218,8 @@ public class ServicePageModel<TInput> : HeaderPageModel
         switch (backUrlPage)
         {
             case ServiceJourneyPage.Time_Details
-                when !ServiceModel!.HowUse.Any(hu => hu is AttendingType.Online or AttendingType.Telephone):
+                when !ServiceModel!.HowUse.Any(hu => hu is AttendingType.Online or AttendingType.Telephone)
+                && ServiceModel.AllLocations.Any():
 
                 backUrlPage = ServiceJourneyPage.Locations_For_Service;
                 break;

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/ServicePageModel.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/ServicePageModel.cs
@@ -217,6 +217,12 @@ public class ServicePageModel<TInput> : HeaderPageModel
         var backUrlPage = CurrentPage - 1;
         switch (backUrlPage)
         {
+            case ServiceJourneyPage.Time_Details
+                when !ServiceModel!.HowUse.Any(hu => hu is AttendingType.Online or AttendingType.Telephone):
+
+                backUrlPage = ServiceJourneyPage.Locations_For_Service;
+                break;
+
             case ServiceJourneyPage.Locations_For_Service:
                 if (!ServiceModel!.HowUse.Contains(AttendingType.InPerson))
                 {

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/ServicePageModel.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/ServicePageModel.cs
@@ -157,12 +157,13 @@ public class ServicePageModel<TInput> : HeaderPageModel
     }
 
     // NextPage should handle skips in a linear journey
-    protected IActionResult NextPage()
+    protected virtual IActionResult NextPage()
     {
         ServiceJourneyPage nextPage;
         switch (Flow)
         {
             case JourneyFlow.Add:
+            case JourneyFlow.AddRedoHowUse:
                 nextPage = CurrentPage + 1;
                 switch (nextPage)
                 {
@@ -178,6 +179,14 @@ public class ServicePageModel<TInput> : HeaderPageModel
 
                         nextPage = ServiceJourneyPage.Contact;
                         break;
+                }
+
+                if (Flow == JourneyFlow.AddRedoHowUse)
+                {
+                    if (nextPage >= ServiceJourneyPage.Contact)
+                    {
+                        nextPage = ServiceJourneyPage.Service_Detail;
+                    }
                 }
                 break;
             case JourneyFlow.AddRedoLocation:

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/ServicePageModel.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/ServicePageModel.cs
@@ -227,6 +227,12 @@ public class ServicePageModel<TInput> : HeaderPageModel
                     backUrlPage = ServiceJourneyPage.Add_Location;
                 }
                 break;
+
+            case ServiceJourneyPage.Add_Location
+                when ServiceModel!.AllLocations.Any():
+
+                backUrlPage = ServiceJourneyPage.Locations_For_Service;
+                break;
         }
 
         return backUrlPage;
@@ -243,7 +249,7 @@ public class ServicePageModel<TInput> : HeaderPageModel
 
             case JourneyFlow.AddRedoLocation:
                 backUrlPage = PreviousPageAddFlow();
-                if (backUrlPage < ServiceJourneyPage.Locations_For_Service)
+                if (CurrentPage == ServiceJourneyPage.Locations_For_Service)
                 {
                     backUrlPage = ServiceJourneyPage.Service_Detail;
                 }
@@ -262,7 +268,13 @@ public class ServicePageModel<TInput> : HeaderPageModel
                 break;
         }
 
-        return GetServicePageUrl(backUrlPage, Flow == JourneyFlow.AddRedo ? JourneyFlow.Add : Flow);
+        //todo: extension IsAddRedoType
+        var backFlow = backUrlPage == ServiceJourneyPage.Service_Detail
+                       && Flow is JourneyFlow.AddRedo or JourneyFlow.AddRedoHowUse or JourneyFlow.AddRedoLocation
+            ? JourneyFlow.Add
+            : Flow;
+
+        return GetServicePageUrl(backUrlPage, backFlow);
     }
 
     //todo: naming?

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/ServicePageModel.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/Shared/ServicePageModel.cs
@@ -256,7 +256,8 @@ public class ServicePageModel<TInput> : HeaderPageModel
 
             case JourneyFlow.AddRedoLocation:
                 backUrlPage = PreviousPageAddFlow();
-                if (CurrentPage == ServiceJourneyPage.Locations_For_Service)
+                if (CurrentPage == ServiceJourneyPage.Locations_For_Service
+                    || backUrlPage <= ServiceJourneyPage.How_Use)
                 {
                     backUrlPage = ServiceJourneyPage.Service_Detail;
                 }

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-locations/Location-Details.cshtml
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-locations/Location-Details.cshtml
@@ -35,20 +35,20 @@
 
         <summary-list>
             <summary-row key="Address" show-empty action1="Change"
-                              action1-href="@Model.GetLocationPageUrl(LocationJourneyPage.Location_Address, Model.Journey, linkFlow)">
+                              action1-href="@Model.GetLocationPageUrl(LocationJourneyPage.Location_Address, Model.Journey, linkFlow, Model.ParentJourneyFlow)">
                 @string.Join(", ", Model.GetAddress())
             </summary-row>
             
             @if (Model.FamilyHubsUser.Role is not (RoleTypes.VcsDualRole or RoleTypes.VcsManager))
             {
                 <summary-row key="Family hub" show-empty action1="Change"
-                                  action1-href="@Model.GetLocationPageUrl(LocationJourneyPage.Family_Hub, Model.Journey, linkFlow)">
+                             action1-href="@Model.GetLocationPageUrl(LocationJourneyPage.Family_Hub, Model.Journey, linkFlow, Model.ParentJourneyFlow)">
                     @(Model.LocationModel!.IsFamilyHub!.Value ? "Yes" : "No")
                 </summary-row>
             }
 
             <summary-row key="More details" show-empty class="fh-pre-wrap" action1="Change"
-                              action1-href="@Model.GetLocationPageUrl(LocationJourneyPage.Location_Information, Model.Journey, linkFlow)">@Model.LocationModel!.Description</summary-row>
+                         action1-href="@Model.GetLocationPageUrl(LocationJourneyPage.Location_Information, Model.Journey, linkFlow, Model.ParentJourneyFlow)">@Model.LocationModel!.Description</summary-row>
         </summary-list>
         
         @if (Model.Flow != JourneyFlow.Edit || Model.LocationModel!.Updated)

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-locations/Location-Details.cshtml.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-locations/Location-Details.cshtml.cs
@@ -52,7 +52,7 @@ public class Location_DetailsModel : LocationPageModel
 
         if (Journey == Journey.Service)
         {
-            return RedirectToPage("/manage-services/Select-Location", new { flow = "add" , locationId = newLocationId});
+            return RedirectToPage("/manage-services/Select-Location", new { flow = ParentJourneyFlow.ToString(), locationId = newLocationId});
         }
 
         return RedirectToPage("/manage-locations/LocationAddedConfirmation");

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-locations/start-add-location.cshtml.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-locations/start-add-location.cshtml.cs
@@ -17,7 +17,7 @@ public class start_add_locationModel : PageModel
         _cache = cache;
     }
 
-    public async Task<IActionResult> OnGetAsync(Journey journey)
+    public async Task<IActionResult> OnGetAsync(Journey journey, JourneyFlow? parentJourneyFlow)
     {
         var familyHubsUser = HttpContext.GetFamilyHubsUser();
 
@@ -33,6 +33,6 @@ public class start_add_locationModel : PageModel
             OrganisationId = organisationId
         });
 
-        return Redirect(LocationJourneyPageExtensions.GetAddFlowStartPagePath(journey));
+        return Redirect(LocationJourneyPageExtensions.GetAddFlowStartPagePath(journey, parentJourneyFlow));
     }
 }

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/How-Use.cshtml.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/How-Use.cshtml.cs
@@ -46,7 +46,9 @@ public class How_UseModel : ServicePageModel, ICheckboxesPageModel
 
         var howUse = SelectedValues.Select(Enum.Parse<AttendingType>).ToArray();
 
-        ServiceModel!.Updated = ServiceModel!.Updated || HasHowUseBeenUpdated(howUse);
+        bool hasJustBeenUpdated = HasHowUseBeenUpdated(howUse);
+
+        ServiceModel!.Updated = ServiceModel!.Updated || hasJustBeenUpdated;
 
         ServiceModel.HowUse = howUse;
 
@@ -60,6 +62,11 @@ public class How_UseModel : ServicePageModel, ICheckboxesPageModel
         if (!howUse.Contains(AttendingType.InPerson))
         {
             ServiceModel.RemoveAllLocations();
+        }
+
+        if (Flow == JourneyFlow.AddRedoHowUse && !hasJustBeenUpdated)
+        {
+            return RedirectToServicePage(ServiceJourneyPage.Service_Detail, Flow);
         }
 
         return NextPage();

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Locations-For-Service.cshtml
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Locations-For-Service.cshtml
@@ -8,6 +8,8 @@
 
     var linkFlow = Model.Flow;
     string redo = ServiceJourneyPage.Locations_For_Service.GetSlug();
+
+    bool hasLocations = Model.Locations.Any();
 }
 
 @section Back {
@@ -18,7 +20,14 @@
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">@title</h1>
 
-        <p>These locations will be added to this service.</p>
+        @if (hasLocations)
+        {
+            <p>These locations will be added to this service.</p>
+        }
+        else
+        {
+            <p>No locations have been added to this service yet.</p>
+        }
 
         <form method="post" novalidate>
             
@@ -52,7 +61,14 @@
                 </button>
                 <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button"
                         name="@Locations_For_ServiceModel.SubmitAction" value="@Locations_For_ServiceModel.SubmitAction_AddAnotherLocation">
-                    Add another location
+                    @if (hasLocations)
+                    {
+                        <text>Add another location</text>
+                    }
+                    else
+                    {
+                        <text>Add location</text>
+                    }
                 </button>
             </div>
         </form>

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Locations-For-Service.cshtml.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Locations-For-Service.cshtml.cs
@@ -19,6 +19,8 @@ public class Locations_For_ServiceModel : ServicePageModel
     {
     }
 
+    //todo: use AllLocations in this page
+
     protected override void OnGetWithModel()
     {
         Locations = ServiceModel!.Locations;

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Locations-For-Service.cshtml.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Locations-For-Service.cshtml.cs
@@ -11,7 +11,7 @@ public class Locations_For_ServiceModel : ServicePageModel
     public const string SubmitAction_Continue = "continue";
     public const string SubmitAction_AddAnotherLocation = "add";
 
-    public List<ServiceLocationModel> Locations { get; set; } = new();
+    public IEnumerable<ServiceLocationModel> Locations { get; private set; } = Enumerable.Empty<ServiceLocationModel>();
 
     public Locations_For_ServiceModel(
         IRequestDistributedCache connectionRequestCache)
@@ -19,14 +19,28 @@ public class Locations_For_ServiceModel : ServicePageModel
     {
     }
 
-    //todo: use AllLocations in this page
-
-    protected override void OnGetWithModel()
+    protected override async Task OnGetWithModelAsync(CancellationToken cancellationToken)
     {
-        Locations = ServiceModel!.Locations;
-        if (ServiceModel.CurrentLocation != null)
+        Locations = ServiceModel!.AllLocations;
+
+        await ResurrectCurrentLocation();
+    }
+
+    /// <summary>
+    /// This is to handle the scenario where the user has clicked add location from this page,
+    /// then clicked back to this page and then will click back again to the location extra details page.
+    /// Without resetting the current location, the location extra details page won't have
+    /// a current location to work with and will explode.
+    /// </summary>
+    /// <returns></returns>
+    private async Task ResurrectCurrentLocation()
+    {
+        if (ServiceModel!.CurrentLocation == null
+            && ServiceModel.Locations.Any())
         {
-            Locations.Add(ServiceModel.CurrentLocation);
+            ServiceModel.CurrentLocation = ServiceModel.Locations.Last();
+            ServiceModel.Locations.Remove(ServiceModel.CurrentLocation);
+            await Cache.SetAsync(FamilyHubsUser.Email, ServiceModel);
         }
     }
 

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Locations-For-Service.cshtml.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Locations-For-Service.cshtml.cs
@@ -33,7 +33,10 @@ public class Locations_For_ServiceModel : ServicePageModel
         string action = Request.Form[SubmitAction].ToString();
         if (action == SubmitAction_AddAnotherLocation)
         {
-            ServiceModel!.Locations.Add(ServiceModel.CurrentLocation!);
+            if (ServiceModel!.CurrentLocation != null)
+            {
+                ServiceModel.Locations.Add(ServiceModel.CurrentLocation);
+            }
             ServiceModel.CurrentLocation = null;
 
             return RedirectToServicePage(ServiceJourneyPage.Select_Location, Flow);

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Remove-Location.cshtml.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Remove-Location.cshtml.cs
@@ -72,7 +72,6 @@ public class Remove_LocationModel : ServicePageModel, IRadiosPageModel
 
         if (SelectedValue == null)
         {
-            //todo: check the flow when redo'ing
             var extraParams = new Dictionary<string, StringValues>
             {
                 { "locationId", locationId.ToString() }
@@ -95,9 +94,10 @@ public class Remove_LocationModel : ServicePageModel, IRadiosPageModel
             }
 
             if (ServiceModel.CurrentLocation == null
-                && !ServiceModel.Locations.Any())
+                && !ServiceModel.Locations.Any()
+                && Flow == JourneyFlow.Add)
             {
-                // user has removed all locations
+                // user has removed all locations and is in the add flow
                 return RedirectToServicePage(ServiceJourneyPage.How_Use, Flow);
             }
         }

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Select-Location.cshtml
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Select-Location.cshtml
@@ -41,7 +41,10 @@
                 </select>
             </div>
 
-            <p>If the location does not appear here you can <a href="/manage-locations/start-add-location?journey=@Journey.Service">add a new location</a>.</p>
+@*             <p>If the location does not appear here you can <a href="/manage-locations/start-add-location?journey=@(Journey.Service)-@(Model.Flow)">add a new location</a>.</p> *@
+            @*             <p>If the location does not appear here you can <a href="/manage-locations/start-add-location?journey=@Journey.Service">add a new location</a>.</p>
+ *@
+            <p>If the location does not appear here you can <a href="/manage-locations/start-add-location?journey=@Journey.Service&parentJourneyFlow=@Model.Flow">add a new location</a>.</p>
 
             <button type="submit" class="govuk-button" data-module="govuk-button">
                 Continue

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Select-Location.cshtml
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Select-Location.cshtml
@@ -41,9 +41,6 @@
                 </select>
             </div>
 
-@*             <p>If the location does not appear here you can <a href="/manage-locations/start-add-location?journey=@(Journey.Service)-@(Model.Flow)">add a new location</a>.</p> *@
-            @*             <p>If the location does not appear here you can <a href="/manage-locations/start-add-location?journey=@Journey.Service">add a new location</a>.</p>
- *@
             <p>If the location does not appear here you can <a href="/manage-locations/start-add-location?journey=@Journey.Service&parentJourneyFlow=@Model.Flow">add a new location</a>.</p>
 
             <button type="submit" class="govuk-button" data-module="govuk-button">

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Select-Location.cshtml.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Select-Location.cshtml.cs
@@ -5,12 +5,12 @@ using FamilyHubs.ServiceDirectory.Admin.Core.Models.ServiceJourney;
 using FamilyHubs.ServiceDirectory.Admin.Web.Pages.Shared;
 using FamilyHubs.ServiceDirectory.Shared.Display;
 using FamilyHubs.ServiceDirectory.Shared.Dto;
-using FamilyHubs.ServiceDirectory.Shared.Enums;
 using FamilyHubs.SharedKernel.Identity;
 using Microsoft.AspNetCore.Mvc;
 
 namespace FamilyHubs.ServiceDirectory.Admin.Web.Pages.manage_services;
 
+//when in AddRedoHowUse mode, and user adds a location, we need to come page in AddRedoHowUse mode
 public class Select_LocationModel : ServicePageModel
 {
     public const int NoSelectionLocationId = -1;

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Select-Location.cshtml.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Select-Location.cshtml.cs
@@ -35,18 +35,21 @@ public class Select_LocationModel : ServicePageModel
         await PopulateLocationsAndName(cancellationToken);
     }
 
+    /// <summary>
+    /// Override to catch the case where the user has clicked 'add' location from the service details page,
+    /// when there were no locations.
+    /// They're sent directly to this page, rather than to an empty 'locations for [service]' page,
+    /// so if they click back, we need to send them back to the service details page.
+    /// We need to look for the query param, as we don't want to break the back link when
+    /// the user has clicked 'add or remove' locations, then removed all locations, then clicked add location.
+    /// As we want to check the query param, it's cleaner to do it here, rather than in the base class.
+    /// </summary>
     protected override string GenerateBackUrl()
     {
         var redoStart = Request.Query["redoStart"];
         if (Flow == JourneyFlow.AddRedoLocation
             && redoStart == true.ToString())
         {
-            // catch the case where the user has clicked 'add' location from the service details page when there were no locations.
-            // they're sent directly to this page, rather than to an empty 'locations for [service]' page,
-            // so if they click back, we need to send them back to the service details page.
-            // we need to look for the query param, as we don't want to break the back link when
-            // the user has clicked 'add or remove' locations, then removed all locations, then clicked add location.
-            // as we want to check the query param, it's cleaner to do it here, rather than in the base class
             return GetServicePageUrl(ServiceJourneyPage.Service_Detail, JourneyFlow.Add);
         }
 

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Select-Location.cshtml.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Select-Location.cshtml.cs
@@ -35,6 +35,24 @@ public class Select_LocationModel : ServicePageModel
         await PopulateLocationsAndName(cancellationToken);
     }
 
+    protected override string GenerateBackUrl()
+    {
+        var redoStart = Request.Query["redoStart"];
+        if (Flow == JourneyFlow.AddRedoLocation
+            && redoStart == true.ToString())
+        {
+            // catch the case where the user has clicked 'add' location from the service details page when there were no locations.
+            // they're sent directly to this page, rather than to an empty 'locations for [service]' page,
+            // so if they click back, we need to send them back to the service details page.
+            // we need to look for the query param, as we don't want to break the back link when
+            // the user has clicked 'add or remove' locations, then removed all locations, then clicked add location.
+            // as we want to check the query param, it's cleaner to do it here, rather than in the base class
+            return GetServicePageUrl(ServiceJourneyPage.Service_Detail, JourneyFlow.Add);
+        }
+
+        return base.GenerateBackUrl();
+    }
+
     protected override async Task OnGetWithModelAsync(CancellationToken cancellationToken)
     {
         await PopulateLocationsAndName(cancellationToken);

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Select-Location.cshtml.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Select-Location.cshtml.cs
@@ -107,12 +107,6 @@ public class Select_LocationModel : ServicePageModel
             .Where(l => !existingLocationIds.Contains(l.Id));
     }
 
-    private async Task<string> GetOrganisationName(long organisationId, CancellationToken cancellationToken)
-    {
-        var organisation = await _serviceDirectoryClient.GetOrganisationById(organisationId, cancellationToken);
-        return organisation.Name;
-    }
-
     private async Task<List<LocationDto>> GetAllLocations(
         string searchName,
         CancellationToken cancellationToken)

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Select-Location.cshtml.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Select-Location.cshtml.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace FamilyHubs.ServiceDirectory.Admin.Web.Pages.manage_services;
 
-//todo: check 2x mini journeys allow user to add a new location + regression test!
 public class Select_LocationModel : ServicePageModel
 {
     public const int NoSelectionLocationId = -1;

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Select-Location.cshtml.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Select-Location.cshtml.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace FamilyHubs.ServiceDirectory.Admin.Web.Pages.manage_services;
 
-//when in AddRedoHowUse mode, and user adds a location, we need to come page in AddRedoHowUse mode
+//todo: check 2x mini journeys allow user to add a new location + regression test!
 public class Select_LocationModel : ServicePageModel
 {
     public const int NoSelectionLocationId = -1;

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml
@@ -172,10 +172,18 @@
             }
         }
 
-        @if (service.HowUse.Any(hu => hu is AttendingType.Online or AttendingType.Telephone)
-        || (service.HowUse.Contains(AttendingType.InPerson) && locationsCount == 0))
+        @{
+            List<AttendingType> howUse = new();
+            if (locationsCount == 0 && service.HowUse.Contains(AttendingType.InPerson))
+            {
+                howUse.Add(AttendingType.InPerson);
+            }
+            howUse.AddRange(service.HowUse.Where(hu => hu != AttendingType.InPerson));
+        }
+
+        @if (howUse.Any())
         {
-            <h3 class="govuk-heading-m">@string.Join(", ", service.HowUse.Select(h => h.ToDescription()))</h3>
+            <h3 class="govuk-heading-m">@string.Join(", ", howUse.Select(h => h.ToDescription()))</h3>
             <summary-list class="govuk-!-margin-bottom-9">
                 <summary-row key="Days service is available" show-empty
                              action1="Change" action1-href="@Model.GetServicePageUrl(ServiceJourneyPage.Times, linkFlow)">

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml
@@ -121,8 +121,18 @@
             
             @if (service.HowUse.Contains(AttendingType.InPerson))
             {
+                var redoLocationUrl = Model.GetServicePageUrl(
+                    locationsCount == 0 ? ServiceJourneyPage.Select_Location : ServiceJourneyPage.Locations_For_Service,
+                    JourneyFlow.AddRedoLocation);
+
+                if (locationsCount == 0)
+                {
+                    redoLocationUrl = $"{redoLocationUrl}&redoStart={true}";
+                }
+
                 <summary-row key="Locations" show-empty
-                             action1="@(locationsCount == 0 ? "Add" : "Add or remove")" action1-href="@Model.GetServicePageUrl(ServiceJourneyPage.Locations_For_Service, JourneyFlow.AddRedoLocation)">
+                             action1="@(locationsCount == 0 ? "Add" : "Add or remove")"
+                             action1-href="@redoLocationUrl">
                     @switch (locationsCount)
                     {
                         case 0:

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml
@@ -115,7 +115,7 @@
         <summary-list class="govuk-!-margin-bottom-9">
 
             <summary-row key="How this service is provided" show-empty
-                              action1="Change" action1-href="@Model.GetServicePageUrl(ServiceJourneyPage.How_Use, linkFlow)">
+                         action1="Change" action1-href="@Model.GetServicePageUrl(ServiceJourneyPage.How_Use, JourneyFlow.AddRedoHowUse)">
                 @string.Join(", ", service.HowUse.Select(hu => hu.ToDescription()))
             </summary-row>
             

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml
@@ -119,11 +119,22 @@
                 @string.Join(", ", service.HowUse.Select(hu => hu.ToDescription()))
             </summary-row>
             
-            @if (locationsCount > 0)
+            @if (service.HowUse.Contains(AttendingType.InPerson))
             {
                 <summary-row key="Locations" show-empty
-                             action1="Add or remove" action1-href="@Model.GetServicePageUrl(ServiceJourneyPage.Locations_For_Service, JourneyFlow.AddRedoLocation)">
-                    @locationsCount @(locationsCount == 1 ? "Location" : "Locations")
+                             action1="@(locationsCount == 0 ? "Add" : "Add or remove")" action1-href="@Model.GetServicePageUrl(ServiceJourneyPage.Locations_For_Service, JourneyFlow.AddRedoLocation)">
+                    @switch (locationsCount)
+                    {
+                        case 0:
+                            <text>No locations</text>
+                            break;
+                        case 1:
+                            <text>1 Location</text>
+                            break;
+                        default:
+                            <text>@locationsCount Locations</text>
+                            break;
+                    }
                 </summary-row>
             }
         </summary-list>

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Service-Detail.cshtml.cs
@@ -44,6 +44,22 @@ public class Service_DetailModel : ServicePageModel
                 .SelectMany(x => x.Value)
                 .ToDictionary(t => t.Id, t => t.Name);
         }
+
+        await ClearErrors();
+    }
+
+    /// <summary>
+    /// Clear down any user errors to handle the case where:
+    /// user clicks change to go back to a previous page in the journey,
+    /// they click continue on that page and errors are displayed due to validation,
+    /// they click back to the details page, then click 'Change' to go back to the same page
+    /// and the validation errors from the first redo visit are shown.
+    /// </summary>
+    /// <returns></returns>
+    private Task ClearErrors()
+    {
+        ServiceModel!.ClearErrors();
+        return Cache.SetAsync(FamilyHubsUser.Email, ServiceModel);
     }
 
     protected override async Task<IActionResult> OnPostWithModelAsync(CancellationToken cancellationToken)

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Time-Details-At-Location.cshtml.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Time-Details-At-Location.cshtml.cs
@@ -60,6 +60,16 @@ public class Time_Details_At_LocationModel : ServicePageModel<TimeDetailsUserInp
             return ServiceModel!.GetLocation(locationId);
         }
 
+        // this works for the page, but then we hit the same issue if the user goes back again
+        //todo: either we don't clear the current location when the user adds a new location
+        // or we properly resurrect current (if user clicks back from select location back to locations for service)
+        // need to be careful we don't break anything else!
+        //if (ServiceModel!.CurrentLocation == null
+        //    && ServiceModel.Locations.Any())
+        //{
+        //    return ServiceModel.Locations.Last();
+        //}
+
         return ServiceModel!.CurrentLocation!;
     }
 

--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Time-Details-At-Location.cshtml.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Pages/manage-services/Time-Details-At-Location.cshtml.cs
@@ -60,16 +60,6 @@ public class Time_Details_At_LocationModel : ServicePageModel<TimeDetailsUserInp
             return ServiceModel!.GetLocation(locationId);
         }
 
-        // this works for the page, but then we hit the same issue if the user goes back again
-        //todo: either we don't clear the current location when the user adds a new location
-        // or we properly resurrect current (if user clicks back from select location back to locations for service)
-        // need to be careful we don't break anything else!
-        //if (ServiceModel!.CurrentLocation == null
-        //    && ServiceModel.Locations.Any())
-        //{
-        //    return ServiceModel.Locations.Last();
-        //}
-
         return ServiceModel!.CurrentLocation!;
     }
 


### PR DESCRIPTION
When the user clicks change against ‘How this service is provided’ on the service details page at the end of the ‘add service’ journey, the user is taken back to the ‘How can people use this service?’ page.

If they don’t change any of the checkbox options, and click continue, they’re taken straight back to the check details page.

If they change any options and then click continue, they’re then taken through all the pages relevant to the new selection, i.e. all the subsequent pages in the journey up to the contact details page, including being able to add and remove locations, create locations and set location and service times and extra details.

Once they’ve gone through all the how-use relevant pages, they’re taken back to the check details page.

Other scenarios covered:

1. when the user has selected just ‘in person’, not added locations, then wants to go back and add locations from the details page. Previously, we didn’t show the locations row, which meant the user couldn’t select ‘add or remove’ locations, to add a location. Now when the user selects ‘in person’, but doesn’t add any locations, we show ‘No locations’ and let them go back and add a location.

2. when the user has selected ‘in person’, adds a location, then goes back to ‘add or remove’ locations, then removes the only location. Instead of taking them back to the ‘How this service is provided’ page (which is the behaviour when removing the last location during the initial add), which doesn’t make much sense when they’ve only asked to change the location, we instead show them the ‘locations for service’ page with no locations, then let them continue back to the details page, or add a new location. We might want to update the content when there are no locations.

This release also contains:

1. working ‘create a location’, as part of the details page’s change location journey (which I suspect was not working properly before this release.)

2. Clicking ‘Back’ from the ‘What is the address?’ page after clicking ‘add a new location’ on the ‘select location’ page, takes the user back to the ‘select location’ page. (It used to go back to the ‘do you want to add any locations’ page, which seems wrong - especially during one of the change mini-journeys, and I couldn’t find any AC in any story to say to do that.)

3. Clicking ‘Back’ from the ‘Search and select a location to add to this service’ page after a location has already been added (i.e. the user clicked ‘Add another location’ from the ‘Locations for Service’ page which already has a location added), now takes the user back to the ‘Locations for service’ page, rather than the ‘add location’ page (which is only valid when adding the initial location).

4. During the add journey, add a location to the service, click to add another location, then click back, then click back again. Previously, the site would display an error page, now it doesn’t.

5. Select ‘In person’ only, add a location, continue through to the ‘How can people find out more about this service?’ page. Previously, the back link took the user to the ‘any more details for the service schedule’ page (which shouldn’t be part of the journey, when telephone or online isn’t selected). Now it takes the user back to the ‘Locations for service’ page.

6. On the service details page, if the user has selected ‘In person’ and added locations, don’t show ‘In person’ in the heading in the ‘Using this service’ section. When a person has selected ‘In person’ and added locations, we capture and display a schedule for each location, and the schedule associated with the service (if there is one) is only relevant for Online/Telephone, so it doesn’t make sense to include ‘In person’ in the heading. 

7. Fixes this scenario:
User clicks Change to go back to a previous page in the journey from the service details page.
They change the data, then click Continue on that page and validation errors are displayed.
They then click ‘Back’ to take them to the service details page.
They then click 'Change' to go back to the same page.
The validation errors from the first redo visit are shown.

Notes:

1. If the user gets to the service details page selecting ‘In person’ and not adding any locations, then clicks ‘Change’ against ‘How this service is provided’, then adds Telephone and/or Online, then clicks continue (which stores their new options), then clicks back to the ‘How this service is provided’ page, then back again to the service details page, their new ‘how service is provided’ options are kept, and the service schedule’s ‘days service is available’ and ‘extra availability details’ are set to ‘None provided’. (I mention this scenario, because it’s a way for the user to get to the service details page without passing through all the relevant mini-journey.)

2. Similarly to 1, when the user initially selects Online/Telephone, and then clicks ‘Change’ against ‘how this service is provided’, adds In Person, and partly completes the add location, then clicks all the way back to the service details page, we accept what they’ve entered, and have defaults for the pages they didn’t complete in the mini journey. It’s not ideal to allow the user to get to the service details page without passing through the appropriate pages, but it makes sense in practice.

3. There are edge cases where the user can loop through location related pages when repeatedly clicking ‘Back’. They can exit the loop by continuing forward through the journey. I think this is probably OK for MVP. We may want to revisit it later.