### PR TITLE
[FHG-5685] Only send email on success

### DIFF
--- a/src/FamilyHubs.ServiceDirectory.Admin.Web/Areas/AccountAdmin/Pages/AddPermissionCheckAnswer.cshtml.cs
+++ b/src/FamilyHubs.ServiceDirectory.Admin.Web/Areas/AccountAdmin/Pages/AddPermissionCheckAnswer.cshtml.cs
@@ -52,12 +52,11 @@ public class AddPermissionCheckAnswer : AccountAdminViewModel
         var organisationId = LaJourney ? _laOrganisationId.ToString() : _vcsOrganisationId.ToString();
         dto.Claims.Add(new AccountClaimDto { Name = FamilyHubsClaimTypes.OrganisationId, Value = organisationId });
 
-        await _emailService.SendAccountPermissionAddedEmail(PermissionModel);
-        
         var outcome = await _idamClient.AddAccount(dto);
 
         if (outcome.IsSuccess)
         {
+            await _emailService.SendAccountPermissionAddedEmail(PermissionModel);
             return RedirectToPage(NextPageLink, new { cacheId = CacheId });
         }
 


### PR DESCRIPTION
Fix for failures when creating VCS users

(Need to move to monorepo)

In future we may want to catch exceptions here and retry or at least feed back to the user that the account was created but the email wasn't sent.